### PR TITLE
update api at 1118

### DIFF
--- a/pkg/schedule/checker/affinity_checker.go
+++ b/pkg/schedule/checker/affinity_checker.go
@@ -100,11 +100,11 @@ func (c *AffinityChecker) Check(region *core.RegionInfo) []*operator.Operator {
 // createAffinityOperator creates an operator to adjust region replicas according to affinity group constraints.
 // Parameters:
 //   - region: The region to adjust
-//   - groupInfo: The affinity group info that defines the desired peer distribution
+//   - groupState: The affinity group info that defines the desired peer distribution
 //
 // Returns:
 //   - *operator.Operator: The operator to adjust the region, or nil if no adjustment is needed
-func (c *AffinityChecker) createAffinityOperator(region *core.RegionInfo, groupInfo *affinity.GroupInfo) *operator.Operator {
+func (c *AffinityChecker) createAffinityOperator(region *core.RegionInfo, groupInfo *affinity.GroupState) *operator.Operator {
 	currentLeaderStoreID := region.GetLeader().GetStoreId()
 	expectedLeaderStoreID := groupInfo.LeaderStoreID
 

--- a/pkg/schedule/checker/affinity_checker_test.go
+++ b/pkg/schedule/checker/affinity_checker_test.go
@@ -120,13 +120,9 @@ func TestAffinityCheckerGroupNotInEffect(t *testing.T) {
 	affinityManager.SetRegionGroup(1, "test_group")
 
 	// Mark group as not in effect
-	groupInfo := affinityManager.GetAffinityGroup("test_group")
-	if groupInfo != nil {
-		// Access internal GroupInfo to modify Effect
-		internalGroupInfo := affinityManager.GetGroups()["test_group"]
-		if internalGroupInfo != nil {
-			internalGroupInfo.Effect = false
-		}
+	internalGroupInfo := affinityManager.GetGroups()["test_group"]
+	if internalGroupInfo != nil {
+		internalGroupInfo.Effect = false
 	}
 
 	// Check should return nil because group is not in effect

--- a/pkg/utils/keypath/absolute_key_path.go
+++ b/pkg/utils/keypath/absolute_key_path.go
@@ -131,7 +131,7 @@ const (
 	timestampPathFormat   = "/pd/%d/timestamp"              // "/pd/{cluster_id}/timestamp"
 	msTimestampPathFormat = "/ms/%d/tso/%05d/gta/timestamp" // "/ms/{cluster_id}/tso/{group_id}/gta/timestamp"
 
-	affinityGroupPathFormat = "/pd/%d/affinity_groups/%s" // "/pd/{cluster_id}/affinity_groups/{group_name}"
+	affinityGroupPathFormat = "/pd/%d/affinity_groups/%s" // "/pd/{cluster_id}/affinity_groups/{group_id}"
 )
 
 // MsParam is the parameter of microservice.

--- a/pkg/utils/keypath/affinity.go
+++ b/pkg/utils/keypath/affinity.go
@@ -19,9 +19,9 @@ import (
 )
 
 // AffinityGroupPath returns the path to save a specific affinity group object.
-// Its format is: "/pd/{cluster_id}/affinity_groups/{group_name}"
-func AffinityGroupPath(groupName string) string {
-	return fmt.Sprintf(affinityGroupPathFormat, ClusterID(), groupName)
+// Its format is: "/pd/{cluster_id}/affinity_groups/{group_id}"
+func AffinityGroupPath(groupID string) string {
+	return fmt.Sprintf(affinityGroupPathFormat, ClusterID(), groupID)
 }
 
 // AffinityGroupsPrefix returns the path prefix for all affinity groups.


### PR DESCRIPTION
1. rename `name` to `id`
2. add `groupID` and `effect` to `GroupState`
3. remove `alloc` function and return `GroupState` directly
4. make `GroupInfo` as private struct
5. use Label.Data rather than map label